### PR TITLE
PR

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,7 @@ HEADERS = attacks.h benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
 		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
 		nnue/nnz_helper.h position.h search.h syzygy/tbprobe.h thread.h thread_native.h timeman.h \
-		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h shm.h shm_linux.h
+		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h shm.h shm_unix.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1198,8 +1198,8 @@ moves_loop:  // When in check, search starts here
                 // (*Scaler): Generally, lower divisors scale well
                 lmrDepth += history / lmrDivisor[dIndex];
 
-                Value futilityValue = ss->staticEval + 39 + 127 * !bestMove + 119 * lmrDepth
-                                    + 90 * (ss->staticEval > alpha);
+                Value futilityValue =
+                  ss->staticEval + 119 * lmrDepth + 90 * (ss->staticEval > alpha) + 164;
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning

--- a/src/shm.h
+++ b/src/shm.h
@@ -36,8 +36,10 @@
 #include <utility>
 #include <variant>
 
-#if defined(__linux__) && !defined(__ANDROID__)
-    #include "shm_linux.h"
+#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__APPLE__) || defined(__FreeBSD__) \
+  || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+    #define USE_UNIX_SHM
+    #include "shm_unix.h"
 #endif
 
 #include "types.h"
@@ -402,7 +404,7 @@ class SharedMemoryBackend {
     std::string last_error_message;
 };
 
-#elif defined(__linux__) && !defined(__ANDROID__)
+#elif defined(USE_UNIX_SHM)
 
 template<typename T>
 class SharedMemoryBackend {
@@ -534,7 +536,7 @@ struct SystemWideSharedConstant {
                       discriminator);
         std::string shm_name = buf;
 
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(USE_UNIX_SHM)
         // POSIX shared memory names must start with a slash
         shm_name = "/sf_" + createHashString(shm_name);
 

--- a/src/shm_unix.h
+++ b/src/shm_unix.h
@@ -16,12 +16,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef SHM_LINUX_H_INCLUDED
-#define SHM_LINUX_H_INCLUDED
-
-#if !defined(__linux__) || defined(__ANDROID__)
-    #error shm_linux.h should not be included on this platform.
-#endif
+#ifndef SHM_UNIX_H_INCLUDED
+#define SHM_UNIX_H_INCLUDED
 
 #include <atomic>
 #include <cassert>
@@ -41,7 +37,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/file.h>
-#include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -50,6 +45,12 @@
 #include <poll.h>
 #include <unistd.h>
 #include <limits.h>
+
+#if defined(__linux__) || defined(__FreeBSD__)
+    // Also gates memfd_create and various CLOEXEC flags
+    #define HAS_EVENTFD
+    #include <sys/eventfd.h>
+#endif
 
 #define SF_MAX_SEM_NAME_LEN NAME_MAX
 
@@ -147,6 +148,7 @@ struct TempRoot {
     }
 };
 
+#ifdef HAS_EVENTFD
 // Allows notifying the background thread that it should close
 struct EventNotifier {
     static std::unique_ptr<EventNotifier> create() noexcept {
@@ -174,6 +176,44 @@ struct EventNotifier {
         event_fd_(fd) {}
     int event_fd_;
 };
+#else
+struct EventNotifier {
+    static std::unique_ptr<EventNotifier> create() noexcept {
+        // Use self-pipe trick
+        int fds[2];
+        if (pipe(fds) == -1)
+            return nullptr;
+
+        for (int fd : fds)
+        {
+            fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+            fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+        }
+
+        return std::unique_ptr<EventNotifier>(new EventNotifier(fds));
+    }
+
+    EventNotifier(const EventNotifier&)             = delete;
+    EventNotifier& operator=(const EventNotifier&)  = delete;
+    EventNotifier& operator=(EventNotifier&& other) = delete;
+    EventNotifier(EventNotifier&& other)            = delete;
+
+    int  get_listener_fd() const noexcept { return fds_[0]; }
+    void send_shutdown() const noexcept {
+        u8                       terminate = 1;
+        [[maybe_unused]] ssize_t unused    = write(fds_[1], &terminate, sizeof(terminate));
+    }
+
+    ~EventNotifier() noexcept {
+        ::close(fds_[0]);
+        ::close(fds_[1]);
+    }
+
+   private:
+    EventNotifier(int fds[2]) { std::memcpy(fds_, fds, sizeof(fds_)); }
+    int fds_[2] = {};
+};
+#endif
 
 // Wrapper around flock() on a file
 struct InitLock {
@@ -388,8 +428,19 @@ class SharedMemory: public detail::SharedMemoryBase {
         return peer_sockets;
     }
 
+    static int create_unix_socket() {
+#ifdef SOCK_CLOEXEC
+        int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+#else
+        int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (fd != -1)
+            (void) fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+#endif
+        return fd;
+    }
+
     std::optional<int> try_receive_memfd(const std::string& their_path) noexcept {
-        int peer_fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        int peer_fd = create_unix_socket();
         if (peer_fd == -1)
             return std::nullopt;
 
@@ -427,7 +478,12 @@ class SharedMemory: public detail::SharedMemoryBase {
             setsockopt(peer_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
             ssize_t bytes_recv;
-            while ((bytes_recv = recvmsg(peer_fd, &msg, MSG_CMSG_CLOEXEC)) < 0 && errno == EINTR)
+#ifdef MSG_CMSG_CLOEXEC
+            int flags = MSG_CMSG_CLOEXEC;
+#else
+            int flags = 0;
+#endif
+            while ((bytes_recv = recvmsg(peer_fd, &msg, flags)) < 0 && errno == EINTR)
             {}
 
             if (bytes_recv > 0)
@@ -438,6 +494,9 @@ class SharedMemory: public detail::SharedMemoryBase {
                 {
                     int received_fd;
                     memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(received_fd));
+#ifndef MSG_CMSG_CLOEXEC
+                    fcntl(received_fd, F_SETFD, fcntl(received_fd, F_GETFD) | FD_CLOEXEC);
+#endif
                     ::close(peer_fd);
                     return received_fd;
                 }
@@ -491,11 +550,19 @@ class SharedMemory: public detail::SharedMemoryBase {
                 {
                     // Another fish wants access
                     int client_fd;
+#ifdef HAS_EVENTFD
                     while ((client_fd = accept4(server_fd, NULL, NULL, SOCK_CLOEXEC)) < 0
                            && errno == EINTR)
                     {}
                     if (client_fd < 0)
                         continue;
+#else
+                    while ((client_fd = accept(server_fd, NULL, NULL)) < 0 && errno == EINTR)
+                    {}
+                    if (client_fd < 0)
+                        continue;
+                    (void) fcntl(client_fd, F_SETFD, fcntl(client_fd, F_GETFD) | FD_CLOEXEC);
+#endif
 
                     msghdr msg    = {};
                     char   buf[1] = {};
@@ -570,10 +637,21 @@ class SharedMemory: public detail::SharedMemoryBase {
 
             if (creator)
             {
+#ifdef HAS_EVENTFD
                 // Failed to get it from a peer (no peers, or only dead peers), so create
                 fd_ = memfd_create("replicated_data", MFD_CLOEXEC);
                 if (fd_ == -1)
                     return false;
+#else
+                char temp_path[PATH_MAX];
+                strncpy(temp_path, "/tmp/stockfish_replicated_data.XXXXXX", PATH_MAX);
+
+                fd_ = mkstemp(temp_path);
+                if (fd_ == -1)
+                    return false;
+                (void) fcntl(fd_, F_SETFD, fcntl(fd_, F_GETFD) | FD_CLOEXEC);
+                unlink(temp_path);
+#endif
 
                 if (ftruncate(fd_, sizeof(T)) != 0)
                 {
@@ -595,7 +673,9 @@ class SharedMemory: public detail::SharedMemoryBase {
                 return false;
             }
 
+#ifdef MADV_HUGEPAGE
             (void) madvise(mapped_mem, sizeof(T), MADV_HUGEPAGE);
+#endif
 
             if (creator)
             {
@@ -611,7 +691,7 @@ class SharedMemory: public detail::SharedMemoryBase {
             if (!shutdown_)
                 return false;
 
-            int server_fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+            int server_fd = create_unix_socket();
             if (server_fd == -1)
                 return false;
 
@@ -650,4 +730,4 @@ template<typename T>
 
 }  // namespace Stockfish::shm
 
-#endif  // #ifndef SHM_LINUX_H_INCLUDED
+#endif  // #ifndef SHM_UNIX_H_INCLUDED


### PR DESCRIPTION
[Copilot is generating a summar
This pull request refactors and extends the shared memory backend to support a wider range of Unix-like platforms (including macOS and BSD variants), not just Linux. It does so by generalizing the previous Linux-specific shared memory implementation and introducing improved portability and fallback mechanisms for system features that are not universally available. Additionally, there are minor improvements to futility pruning logic and some build system adjustments.

**Portability and Shared Memory Backend Refactoring:**

* Generalized the shared memory backend from a Linux-specific implementation (`shm_linux.h`) to a Unix-wide implementation (`shm_unix.h`), enabling support for macOS, FreeBSD, OpenBSD, NetBSD, and DragonFly BSD, in addition to Linux. The relevant header is now conditionally included based on platform detection, and the build system references were updated accordingly. [[1]](diffhunk://#diff-0c17bb59c937a6974e1b5048e22ff575ba46e46e805e1646d5faa8c8a912a0fbL39-R42) [[2]](diffhunk://#diff-0c17bb59c937a6974e1b5048e22ff575ba46e46e805e1646d5faa8c8a912a0fbL405-R407) [[3]](diffhunk://#diff-0c17bb59c937a6974e1b5048e22ff575ba46e46e805e1646d5faa8c8a912a0fbL537-R539) [[4]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L19-R20) [[5]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L653-R733) [[6]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L94-R94)

* Introduced platform feature detection and fallback logic:  
  - Uses `eventfd` and `memfd_create` where available (Linux/FreeBSD), and falls back to self-pipe and `mkstemp` on platforms lacking these features.  
  - Socket and file descriptor flags (e.g., `SOCK_CLOEXEC`, `MSG_CMSG_CLOEXEC`, `FD_CLOEXEC`) are now conditionally used or emulated for compatibility. [[1]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L44) [[2]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R49-R54) [[3]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R151) [[4]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R179-R216) [[5]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R431-R443) [[6]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L430-R486) [[7]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R497-R499) [[8]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R553-R565) [[9]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R640-R654) [[10]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8R676-R678) [[11]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L614-R694)

**Build System and File Renaming:**

* Renamed `shm_linux.h` to `shm_unix.h` and updated all references in the build system and codebase to use the new, more general header. [[1]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L94-R94) [[2]](diffhunk://#diff-b30e3d1eb327b6a74117d13b0a55f650db60668d7d4bd36ad1e24336260843a8L19-R20)

**Engine Logic Improvement:**

* Adjusted futility pruning logic in the search code to simplify and slightly alter the calculation of the futility value, potentially affecting search efficiency and pruning behavior.y...]